### PR TITLE
修复标签逗号分割与历史数据规范化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ ALIYUN_OSS_PUBLIC_BASE=
 
 # 运行时
 NODE_ENV=development
+
+# 可选：标签分隔符提示（当前代码默认逗号，无需配置）
+# TAGS_DELIMITER=,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.2.1 (2025-09-08)
+
+Fixes
+- Tags：修复提交/编辑时的标签未按逗号拆分的问题；统一为小写、去重，并为历史数据执行一次性规范化。
+
+Database
+- 迁移：005_tags_normalization.sql
+  - 新增函数 public.normalize_tags(text[])、触发器 before insert/update 规范化 apps.tags
+  - 一次性更新历史数据，并添加 GIN 索引 idx_apps_tags_gin
+
+Upgrade Notes
+1) 在 Supabase SQL Editor 或迁移流水线上执行 supabase/migrations/005_tags_normalization.sql
+2) 无需代码改动配置，前后端已内建拆分与清洗逻辑
+
+Rollback
+- 可安全删除触发器与函数并移除索引：
+  - drop trigger if exists trg_apps_tags_normalize on public.apps;
+  - drop function if exists public.before_apps_tags_normalize();
+  - drop function if exists public.normalize_tags(text[]);
+  - drop index if exists idx_apps_tags_gin;
+
 ## v0.2.0 (2025-08-20)
 
 Features

--- a/app/edit/[id]/page.tsx
+++ b/app/edit/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, FormEvent } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { useI18n } from '@/lib/i18n';
+import { parseTags } from '@/lib/tags';
 
 export default function EditPage({ params }: { params: { id: string } }) {
   const { t } = useI18n();
@@ -59,7 +60,7 @@ export default function EditPage({ params }: { params: { id: string } }) {
         <textarea className="w-full border rounded-xl px-3 py-2" rows={4} value={app.description || ''} onChange={e => setApp({ ...app, description: e.target.value })} placeholder="简介" />
         <input className="w-full border rounded-xl px-3 py-2" value={app.play_url || ''} onChange={e => setApp({ ...app, play_url: e.target.value })} placeholder="链接" required />
         <input className="w-full border rounded-xl px-3 py-2" value={app.cover_url || ''} onChange={e => setApp({ ...app, cover_url: e.target.value })} placeholder="封面图链接" />
-        <input className="w-full border rounded-xl px-3 py-2" value={(app.tags || []).join(', ')} onChange={e => setApp({ ...app, tags: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })} placeholder="标签（逗号分隔）" />
+  <input className="w-full border rounded-xl px-3 py-2" value={(app.tags || []).join(', ')} onChange={e => setApp({ ...app, tags: parseTags(e.target.value) })} placeholder="标签（逗号分隔）" />
         <div className="flex items-center gap-3">
           <label className="text-sm">状态</label>
           <select className="border rounded-xl px-2 py-1" value={app.status || 'active'} onChange={e => setApp({ ...app, status: e.target.value })}>

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from '@/lib/supabaseClient';
 import slugify from 'slugify';
 import { useI18n } from '@/lib/i18n';
 import { z } from 'zod';
+import { parseTags } from '@/lib/tags';
 
 const SubmitSchema = z.object({
   title: z.string().min(1, '标题必填'),
@@ -86,7 +87,7 @@ export default function SubmitPage() {
         cover_url: form.cover_url.trim() || null,
         play_url: form.play_url.trim(),
         source_host: (() => { try { return new URL(form.play_url).host } catch { return null } })(),
-        tags: form.tags.split(',').map(s => s.trim()).filter(Boolean),
+  tags: parseTags(form.tags),
         status: 'active',
         owner_id: ownerId,
         owner_email: userEmail,

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,0 +1,11 @@
+// 工具：将逗号分隔的标签字符串标准化为数组；或将任意字符串数组清洗（trim/lower/去重）
+export function parseTags(input: string | string[] | null | undefined): string[] {
+  if (!input) return [];
+  const parts = Array.isArray(input)
+    ? input
+    : String(input).split(',');
+  const cleaned = parts
+    .map((s) => (s ?? '').trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  return Array.from(new Set(cleaned));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-mini-app-hub",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-mini-app-hub",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@supabase/auth-ui-react": "0.4.7",
         "@supabase/auth-ui-shared": "0.1.7",

--- a/supabase/migrations/005_tags_normalization.sql
+++ b/supabase/migrations/005_tags_normalization.sql
@@ -1,0 +1,61 @@
+-- 005_tags_normalization.sql
+-- 目的：修复历史数据里将整串逗号分隔标签当作一个元素存入 text[] 的问题；并通过触发器保证后续写入被规范化。
+
+-- 1) 规范化函数：
+--    - 将数组每个元素用逗号拆分
+--    - 去除首尾空格、转小写
+--    - 过滤空值
+--    - 去重并排序（稳定展示与便于比较）
+create or replace function public.normalize_tags(arr text[])
+returns text[] language plpgsql immutable as $$
+declare
+  v text;
+  item text;
+  tmp text[] := '{}';
+begin
+  if arr is null then
+    return '{}';
+  end if;
+
+  -- 拆分、清洗
+  foreach v in array arr loop
+    if v is null then
+      continue;
+    end if;
+    for item in select trim(both ' ' from lower(x)) from regexp_split_to_table(v, '\s*,\s*') as t(x) loop
+      if item is not null and length(item) > 0 then
+        tmp := array_append(tmp, item);
+      end if;
+    end loop;
+  end loop;
+
+  -- 去重
+  tmp := (select array_agg(distinct x) from unnest(tmp) as u(x));
+  if tmp is null then
+    tmp := '{}';
+  end if;
+
+  -- 排序
+  return (select coalesce(array_agg(x order by x), '{}') from unnest(tmp) as u(x));
+end;
+$$;
+
+-- 2) 触发器：在 insert/update 前规范化
+create or replace function public.before_apps_tags_normalize()
+returns trigger language plpgsql as $$
+begin
+  new.tags := public.normalize_tags(new.tags);
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_apps_tags_normalize on public.apps;
+create trigger trg_apps_tags_normalize
+before insert or update on public.apps
+for each row execute function public.before_apps_tags_normalize();
+
+-- 3) 一次性修复历史数据
+update public.apps set tags = public.normalize_tags(tags) where tags is not null;
+
+-- 4) 索引：为包含查询提供加速（如后续添加 where tags && '{ai,chat}'::text[]）
+create index if not exists idx_apps_tags_gin on public.apps using gin (tags);


### PR DESCRIPTION
- 修复提交/编辑时标签未按逗号拆分的问题，统一小写、去重
- 新增 supabase/migrations/005_tags_normalization.sql 规范化历史数据与后续写入
- .env.example 增加分隔符说明
- CHANGELOG.md 记录升级与回滚说明
- 已通过所有单元测试

合并后请在 Supabase SQL Editor 执行迁移脚本，历史数据将自动修复。